### PR TITLE
Updating dependencies. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.2.RELEASE</version>
+        <version>2.7.6</version>
         <relativePath/>
     </parent>
     <groupId>com.joshlong</groupId>
     <artifactId>
          git-spring-boot-starter
     </artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <properties>
         <jgit.version>6.3.0.202209071007-r</jgit.version>
         <java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
     </artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <properties>
-        <jgit.version>4.11.0.201803080745-r</jgit.version>
+        <jgit.version>6.3.0.202209071007-r</jgit.version>
         <java.version>11</java.version>
-        <jsch.version>0.1.54</jsch.version>
+        <jsch.version>0.1.55</jsch.version>
     </properties>
 
     <dependencies>
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>io.spring.javaformat</groupId>
                 <artifactId>spring-javaformat-maven-plugin</artifactId>
-                <version>0.0.19</version>
+                <version>0.0.33</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.jfrog.buildinfo</groupId>
                 <artifactId>artifactory-maven-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>3.4.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>


### PR DESCRIPTION
Using the latest jgit lets us set a clone depth. This adds a huge speed improvement to bootiful-asciidoctor, especially if the repo has binaries.